### PR TITLE
fix(update forward refs): change to issubclass

### DIFF
--- a/openapi-python-templates/__init__package.mustache
+++ b/openapi-python-templates/__init__package.mustache
@@ -8,5 +8,5 @@ from @IMPORT_NAME@.api_client import ApiClient, AsyncApis, SyncApis  # noqa F401
 for model in inspect.getmembers(models, inspect.isclass):
 	if model[1].__module__ == "@IMPORT_NAME@.models":
 		model_class = model[1]
-		if isinstance(model_class, BaseModel):
+		if issubclass(model_class, BaseModel):
 			model_class.update_forward_refs()


### PR DESCRIPTION
Fix to this issue: https://github.com/dmontagu/fastapi_client/issues/27

@heidimhurst - I think you mentioned some `update_forward_refs()`? This came up too when I was doing some testing on the `IO` change. Did a bunch of digging only to find it's a well known issue :upside_down_face: 