### PR TITLE
fix: allow pydantic v2

### DIFF
--- a/example/client/__init__.py
+++ b/example/client/__init__.py
@@ -1,6 +1,9 @@
 import inspect
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from example.client import models
 from example.client.api_client import ApiClient, AsyncApis, SyncApis  # noqa F401

--- a/example/client/api_client.py
+++ b/example/client/api_client.py
@@ -2,7 +2,10 @@ from asyncio import get_event_loop
 from typing import Any, Awaitable, Callable, Dict, Generic, Type, TypeVar, overload
 
 from httpx import AsyncClient, Request, Response
-from pydantic import ValidationError, parse_obj_as
+try:
+    from pydantic.v1 import ValidationError, parse_obj_as
+except ImportError:
+    from pydantic import ValidationError, parse_obj_as
 
 from example.client.api.pet_api import AsyncPetApi, SyncPetApi
 from example.client.api.store_api import AsyncStoreApi, SyncStoreApi

--- a/example/client/auth.py
+++ b/example/client/auth.py
@@ -4,7 +4,10 @@ from typing import Optional
 
 from fastapi.openapi.models import OAuthFlowPassword
 from httpx import Request, Response
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from example.client.api_client import Send
 from example.client.exceptions import UnexpectedResponse

--- a/example/client/models.py
+++ b/example/client/models.py
@@ -2,7 +2,10 @@ from datetime import datetime
 from typing import Any  # noqa
 from typing import List, Optional
 
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 from typing_extensions import Literal
 
 

--- a/example/client/password_flow_client.py
+++ b/example/client/password_flow_client.py
@@ -8,7 +8,10 @@ from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 from fastapi.openapi.models import OAuthFlowPassword
 from httpx import AsyncClient, Response
-from pydantic import BaseModel, ValidationError
+try:
+    from pydantic.v1 import BaseModel, ValidationError
+except ImportError:
+    from pydantic import BaseModel, ValidationError
 from typing_extensions import Literal
 
 from example.client.exceptions import UnexpectedResponse

--- a/openapi-python-templates/__init__package.mustache
+++ b/openapi-python-templates/__init__package.mustache
@@ -1,5 +1,8 @@
 import inspect
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from @IMPORT_NAME@ import models
 from @IMPORT_NAME@.api_client import ApiClient, AsyncApis, SyncApis  # noqa F401

--- a/openapi-python-templates/api_client.mustache
+++ b/openapi-python-templates/api_client.mustache
@@ -2,7 +2,10 @@ from asyncio import get_event_loop
 from typing import Any, Awaitable, Callable, Dict, Generic, Type, TypeVar, overload
 
 from httpx import AsyncClient, Request, Response
-from pydantic import ValidationError, parse_obj_as
+try:
+    from pydantic.v1 import ValidationError, parse_obj_as
+except ImportError:
+    from pydantic import ValidationError, parse_obj_as
 
 {{#apiInfo}}{{#apis}}from @IMPORT_NAME@.api.{{classVarName}} import Async{{classname}}, Sync{{classname}}
 {{/apis}}{{/apiInfo}}from @IMPORT_NAME@.exceptions import ResponseHandlingException, UnexpectedResponse

--- a/openapi-python-templates/model.mustache
+++ b/openapi-python-templates/model.mustache
@@ -3,7 +3,10 @@ from typing import Optional, List, Dict
 from typing import Any  # noqa
 from typing_extensions import Literal
 from uuid import UUID
-from pydantic import BaseModel, Field
+try:
+    from pydantic.v1 import BaseModel, Field
+except ImportError:
+    from pydantic import BaseModel, Field
 
 {{#models}}
 {{#model}}

--- a/other-templates/auth.template
+++ b/other-templates/auth.template
@@ -4,7 +4,10 @@ from typing import Optional
 
 from fastapi.openapi.models import OAuthFlowPassword
 from httpx import Request, Response
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 
 from @IMPORT_NAME@.api_client import Send
 from @IMPORT_NAME@.exceptions import UnexpectedResponse

--- a/other-templates/password_flow_client.template
+++ b/other-templates/password_flow_client.template
@@ -8,7 +8,10 @@ from typing import Any, Dict, List, Optional, Type, TypeVar, Union
 
 from fastapi.openapi.models import OAuthFlowPassword
 from httpx import AsyncClient, Response
-from pydantic import BaseModel, ValidationError
+try:
+    from pydantic.v1 import BaseModel, ValidationError
+except ImportError:
+    from pydantic import BaseModel, ValidationError
 from typing_extensions import Literal
 
 from @IMPORT_NAME@.exceptions import UnexpectedResponse

--- a/tests/server_app/models.py
+++ b/tests/server_app/models.py
@@ -5,7 +5,10 @@ Pydantic data models for the server.
 
 from typing import List, Optional
 
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except:
+    from pydantic import BaseModel
 
 
 class FormPostResponse(BaseModel):

--- a/tests/server_app/routers/auth.py
+++ b/tests/server_app/routers/auth.py
@@ -5,7 +5,10 @@ from typing import Optional
 
 from fastapi import APIRouter, Depends, HTTPException
 from fastapi.security import OAuth2PasswordBearer, OAuth2PasswordRequestForm
-from pydantic import BaseModel
+try:
+    from pydantic.v1 import BaseModel
+except ImportError:
+    from pydantic import BaseModel
 from starlette.responses import JSONResponse
 from starlette.status import HTTP_401_UNAUTHORIZED
 


### PR DESCRIPTION
## Background

Some users of this client would like to install `pydantic>=2`.  However, when using these data models, validation errors are raised because they are not compatible with v2:

```
pydantic_core._pydantic_core.ValidationError: 5 validation errors for AuthState
username
  Field required [type=missing, input_value={'access_token': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
password
  Field required [type=missing, input_value={'access_token': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
refresh_token
  Field required [type=missing, input_value={'access_token': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
expires_at
  Field required [type=missing, input_value={'access_token': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
scope
  Field required [type=missing, input_value={'access_token': None}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.4/v/missing
```

Although we could adjust the data models to conform with v2, that would prevent users from continuing to use this client with v1.

Instead, we take advantage of [the backwards compatibility that pydantic v2 provides](https://docs.pydantic.dev/latest/migration/#continue-using-pydantic-v1-features:~:text=The%20Pydantic%20V2%20package%20also%20continues%20to%20provide%20access%20to%20the%20Pydantic%20V1%20API%20by%20importing%20through%20pydantic.v1) so that we can use v1 data models whether v2 or v1 pydantic are installed.

## Testing

I haven't managed to get this working just yet.  Here is my work after a lot of trial-and-error

```shell
docker run --rm -it -v $(pwd):/src python:3.7 bash ;
cd /src ;
pip install poetry ;
make develop ;
pip install fastapi 'pydantic<2' python-multipart uvicorn ;
pip install pytest ;
make test ;
./scripts/dev/test.sh
Starting server app
Exit: Failed to start the server, exit code 1
Logs are in logs/server.log
make: *** [Makefile:43: test] Error 2
```

## Pushplan

I'm honestly planning on just merging this, bumping the client in `marketplace-supply`, verifying that it works there, and then circling back (or reverting) if it doesn't.  Any objections?

```python
from marketplace_supply.client import supply_client

client = supply_client.get_sync_client(host="https://marketplace-supply.stage.pachama.com/")
project = client.projects_api.read_project_projects_slug_get(slug="biocorredor-martin-sagrado-redd-project-oct-26")
print(project)
```